### PR TITLE
Set monolog log paths for when@prod

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -45,11 +45,11 @@ when@prod:
                 action_level: error
                 handler: nested
                 excluded_http_codes: [404, 405]
-                buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+                buffer_size: 50
             nested:
                 type: stream
-                path: php://stderr
-                level: debug
+                path: "%kernel.logs_dir%/%kernel.environment%.log"
+                level: error
                 formatter: monolog.formatter.json
             console:
                 type: console
@@ -58,5 +58,5 @@ when@prod:
             deprecation:
                 type: stream
                 channels: [deprecation]
-                path: php://stderr
+                path: "%kernel.logs_dir%/deprecation.log"
                 formatter: monolog.formatter.json


### PR DESCRIPTION
### To Do
Application logs are not saved in var/log, fix this, save them in prod.log

### Proof of Implementation 
`(Insert screenshots of completed work)`

### Trello Link
`(Paste the link to the Trello task)`
