### PR TITLE
FIx/Add --no-dev flag to composer install in CD configuration

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,7 +47,7 @@ jobs:
             source ~/.bashrc
             git fetch
             git reset --hard origin/main
-            composer install
+            composer install --no-dev --optimize-autoloader
             npx yarn install
             npx yarn build
             php bin/console sass:build


### PR DESCRIPTION
### To Do
Add --no-dev flag to composer install in CD configuration

### Proof of Implementation 
`(Insert screenshots of completed work)`

### Trello Link
`(Paste the link to the Trello task)`
